### PR TITLE
[Fix] Copybara config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ $ bash download_from_zenodo.sh $DATASET_ROOTDIR_PATH
 
 ### Preprocessed Dataset
 
-Sensors used in the OpenPack dataset have different sampling rate.
-Therefore, each sensor is stored in a separate file. When you use them, you have to combine them using timestamps assosiated with each record. But it's not easy for the new commer.
+Sensors used in the OpenPack dataset have different sampling rates.
+Therefore, each sensor is stored in a separate file. When you use them, you have to combine them using timestamps assosiated with each record. But we understand that it's not easy for the new commer.
 
-Therefore, we prepared pre-processed data for the quick trial.
+Therefore, we prepared pre-processed dataset for the quick trial.
 IMU data from 4 sensors and work operation labels are combined into one CSV file.
-This preprocessd dataset is available on [zenodo - preprocessed-IMU-with-operation-labels.zip](https://zenodo.org/records/8145223).
+This preprocessd dataset is available on [zenodo (preprocessed-IMU-with-operation-labels.zip)](https://zenodo.org/records/8145223).
 
 For more details, see [data-stream/preprocessed](./docs/data-stream/preprocessed.md).
 
 ### Sample Dataset
 
 Sample data including RGB images is available in [./data/openpack/](./data/openpack/).
-You can used these files to check content and file format before downloading the full dataset.
+You can used these files to check contents and file formats before downloading the full dataset.
 
 ## Tools & Ecosystem
 

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -14,17 +14,17 @@ core.workflow(
         url = openpackToolkitUrl,
         destination_ref = "main",
         pr_branch = "feat/copybara/from-openpack-dataset",
-        title="[feat][CopyBara] Changes from openpack-dataset (${CONTEXT_REFERENCE})",
+        title="[feat][CopyBara] Changes from openpack-dataset",
         update_description=True,
         integrates = [],
     ),
     origin_files = glob(["docs/**", "data/openpack/**"]),
-    destination_files = glob(["docs/openpack-dataset/**", "sample/openpack/**"]),
+    destination_files = glob(["docs/openpack-dataset/**", "samples/openpack/**"]),
     authoring = authoring.pass_thru("Copybara <yoshimura708x@gmail.com>"),
 
     # Change the path here to the folder you want to publish publicly
     transformations = [
 	    core.move("docs/", "docs/openpack-dataset/"),
-	    core.move("data/openpack/", "sample/openpack/"),
+	    core.move("data/openpack/", "samples/openpack/"),
 	],
 )


### PR DESCRIPTION
# Context

Sample files are copied to `sample/` directory by CopyBara.
But `samples/` (with `s`) is the correct place. This PR fix this errors.

## Minor Changes 🐛 

- [x] Change the target directory of the sample data (`sample/` -> `samples/`)
- [x] Fix typo